### PR TITLE
feat: add config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,44 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "api"
 version = "0.1.0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bundle"
@@ -15,6 +51,21 @@ name = "cdn"
 version = "0.1.0"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "config"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "connections"
 version = "0.1.0"
 
@@ -23,9 +74,253 @@ name = "gateway"
 version = "0.1.0"
 
 [[package]]
-name = "util"
-version = "0.1.0"
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "webrtc"
 version = "0.1.0"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "crates/cdn",
     "crates/connections",
     "crates/gateway",
-    "crates/util",
+    "crates/util/config",
     "crates/webrtc",
 ]
 resolver = "2"

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "util"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]

--- a/crates/util/config/Cargo.toml
+++ b/crates/util/config/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "config"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "sync"] }

--- a/crates/util/config/src/lib.rs
+++ b/crates/util/config/src/lib.rs
@@ -1,0 +1,997 @@
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+static CONFIG: OnceCell<Arc<Config>> = OnceCell::const_new();
+
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct Config {
+    pub gateway: EndpointConfiguration,
+    pub cdn: CdnConfiguration,
+    pub api: ApiConfiguration,
+    pub general: GeneralConfiguration,
+    pub limits: LimitsConfiguration,
+    pub security: SecurityConfiguration,
+    pub login: LoginConfiguration,
+    pub register: RegisterConfiguration,
+    pub regions: RegionConfiguration,
+    pub guild: GuildConfiguration,
+    pub gif: GifConfiguration,
+    pub rabbitmq: RabbitMQConfiguration,
+    pub kafka: KafkaConfiguration,
+    pub templates: TemplateConfiguration,
+    pub metrics: MetricsConfiguration,
+    pub sentry: SentryConfiguration,
+    pub defaults: DefaultsConfiguration,
+    pub external: ExternalTokensConfiguration,
+    pub email: EmailConfiguration,
+    #[serde(rename = "passwordReset")]
+    pub password_reset: PasswordResetConfiguration,
+    pub user: UserConfiguration,
+}
+
+impl Config {
+    pub async fn init() -> Arc<Self> {
+        CONFIG
+            .get_or_init(|| async {
+                let path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.json".to_string());
+                let cfg = match tokio::fs::read_to_string(&path).await {
+                    Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+                    Err(_) => Self::default(),
+                };
+                Arc::new(cfg)
+            })
+            .await
+            .clone()
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct EndpointConfiguration {
+    pub endpoint_client: Option<String>,
+    pub endpoint_private: Option<String>,
+    pub endpoint_public: Option<String>,
+}
+impl Default for EndpointConfiguration {
+    fn default() -> Self {
+        Self {
+            endpoint_client: None,
+            endpoint_private: None,
+            endpoint_public: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct CdnConfiguration {
+    #[serde(flatten)]
+    pub endpoint: EndpointConfiguration,
+    pub resize_height_max: u32,
+    pub resize_width_max: u32,
+    pub imagor_server_url: Option<String>,
+    pub proxy_cache_header_seconds: u32,
+}
+impl Default for CdnConfiguration {
+    fn default() -> Self {
+        Self {
+            endpoint: EndpointConfiguration::default(),
+            resize_height_max: 1000,
+            resize_width_max: 1000,
+            imagor_server_url: None,
+            proxy_cache_header_seconds: 60 * 60 * 24,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ApiConfiguration {
+    pub default_version: String,
+    pub active_versions: Vec<String>,
+    pub endpoint_public: Option<String>,
+}
+impl Default for ApiConfiguration {
+    fn default() -> Self {
+        Self {
+            default_version: "9".into(),
+            active_versions: vec!["6".into(), "7".into(), "8".into(), "9".into()],
+            endpoint_public: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GeneralConfiguration {
+    pub instance_name: String,
+    pub instance_description: Option<String>,
+    pub front_page: Option<String>,
+    pub tos_page: Option<String>,
+    pub correspondence_email: Option<String>,
+    pub correspondence_user_id: Option<String>,
+    pub image: Option<String>,
+    pub instance_id: String,
+    pub auto_create_bot_users: bool,
+}
+impl Default for GeneralConfiguration {
+    fn default() -> Self {
+        Self {
+            instance_name: "Spacebar Instance".into(),
+            instance_description: Some(
+                "This is a Spacebar instance made in the pre-release days".into(),
+            ),
+            front_page: None,
+            tos_page: None,
+            correspondence_email: None,
+            correspondence_user_id: None,
+            image: None,
+            instance_id: "0".into(),
+            auto_create_bot_users: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GifConfiguration {
+    pub enabled: bool,
+    pub provider: String,
+    pub api_key: Option<String>,
+}
+impl Default for GifConfiguration {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            provider: "tenor".into(),
+            api_key: Some("LIVDSRZULELA".into()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RabbitMQConfiguration {
+    pub host: Option<String>,
+}
+impl Default for RabbitMQConfiguration {
+    fn default() -> Self {
+        Self { host: None }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct KafkaConfiguration {
+    pub brokers: Option<Vec<KafkaBroker>>,
+}
+impl Default for KafkaConfiguration {
+    fn default() -> Self {
+        Self { brokers: None }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct KafkaBroker {
+    pub ip: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct TemplateConfiguration {
+    pub enabled: bool,
+    pub allow_template_creation: bool,
+    pub allow_discord_templates: bool,
+    pub allow_raws: bool,
+}
+impl Default for TemplateConfiguration {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            allow_template_creation: true,
+            allow_discord_templates: true,
+            allow_raws: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct MetricsConfiguration {
+    pub timeout: u32,
+}
+impl Default for MetricsConfiguration {
+    fn default() -> Self {
+        Self { timeout: 30000 }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct SentryConfiguration {
+    pub enabled: bool,
+    pub endpoint: String,
+    pub trace_sample_rate: f32,
+    pub environment: Option<String>,
+}
+impl Default for SentryConfiguration {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: "https://05e8e3d005f34b7d97e920ae5870a5e5@sentry.thearcanebrony.net/6"
+                .into(),
+            trace_sample_rate: 1.0,
+            environment: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct DefaultsConfiguration {
+    pub guild: GuildDefaults,
+    pub user: UserDefaults,
+}
+impl Default for DefaultsConfiguration {
+    fn default() -> Self {
+        Self {
+            guild: GuildDefaults::default(),
+            user: UserDefaults::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GuildDefaults {
+    pub max_presences: u32,
+    pub max_video_channel_users: u32,
+    pub afk_timeout: u32,
+    pub default_message_notifications: u32,
+    pub explicit_content_filter: u32,
+}
+impl Default for GuildDefaults {
+    fn default() -> Self {
+        Self {
+            max_presences: 250000,
+            max_video_channel_users: 200,
+            afk_timeout: 300,
+            default_message_notifications: 1,
+            explicit_content_filter: 0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct UserDefaults {
+    pub premium: bool,
+    pub premium_type: u32,
+    pub verified: bool,
+}
+impl Default for UserDefaults {
+    fn default() -> Self {
+        Self {
+            premium: true,
+            premium_type: 2,
+            verified: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ExternalTokensConfiguration {
+    pub twitter: Option<String>,
+}
+impl Default for ExternalTokensConfiguration {
+    fn default() -> Self {
+        Self { twitter: None }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct EmailConfiguration {
+    pub provider: Option<String>,
+    pub sender_address: Option<String>,
+    pub smtp: SMTPConfiguration,
+    pub mailgun: MailGunConfiguration,
+    pub mailjet: MailJetConfiguration,
+    pub sendgrid: SendGridConfiguration,
+}
+impl Default for EmailConfiguration {
+    fn default() -> Self {
+        Self {
+            provider: None,
+            sender_address: None,
+            smtp: SMTPConfiguration::default(),
+            mailgun: MailGunConfiguration::default(),
+            mailjet: MailJetConfiguration::default(),
+            sendgrid: SendGridConfiguration::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct SMTPConfiguration {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub secure: Option<bool>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+impl Default for SMTPConfiguration {
+    fn default() -> Self {
+        Self {
+            host: None,
+            port: None,
+            secure: None,
+            username: None,
+            password: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct MailGunConfiguration {
+    pub api_key: Option<String>,
+    pub domain: Option<String>,
+}
+impl Default for MailGunConfiguration {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            domain: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct MailJetConfiguration {
+    pub api_key: Option<String>,
+    pub api_secret: Option<String>,
+}
+impl Default for MailJetConfiguration {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            api_secret: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct SendGridConfiguration {
+    pub api_key: Option<String>,
+}
+impl Default for SendGridConfiguration {
+    fn default() -> Self {
+        Self { api_key: None }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PasswordResetConfiguration {
+    pub require_captcha: bool,
+}
+impl Default for PasswordResetConfiguration {
+    fn default() -> Self {
+        Self {
+            require_captcha: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct UserConfiguration {
+    pub blocked_contains: Vec<String>,
+    pub blocked_equals: Vec<String>,
+}
+impl Default for UserConfiguration {
+    fn default() -> Self {
+        Self {
+            blocked_contains: vec!["discord".into(), "clyde".into(), "spacebar".into()],
+            blocked_equals: vec!["everyone".into(), "here".into()],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RegionConfiguration {
+    pub default: String,
+    pub use_default_as_optimal: bool,
+    pub available: Vec<Region>,
+}
+impl Default for RegionConfiguration {
+    fn default() -> Self {
+        Self {
+            default: "spacebar".into(),
+            use_default_as_optimal: true,
+            available: vec![Region::default()],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct Region {
+    pub id: String,
+    pub name: String,
+    pub endpoint: String,
+    pub location: Option<Location>,
+    pub vip: bool,
+    pub custom: bool,
+    pub deprecated: bool,
+}
+impl Default for Region {
+    fn default() -> Self {
+        Self {
+            id: "spacebar".into(),
+            name: "spacebar".into(),
+            endpoint: "127.0.0.1:3004".into(),
+            location: None,
+            vip: false,
+            custom: false,
+            deprecated: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct Location {
+    pub latitude: f64,
+    pub longitude: f64,
+}
+impl Default for Location {
+    fn default() -> Self {
+        Self {
+            latitude: 0.0,
+            longitude: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GuildConfiguration {
+    pub discovery: DiscoveryConfiguration,
+    #[serde(rename = "autoJoin")]
+    pub auto_join: AutoJoinConfiguration,
+    #[serde(rename = "defaultFeatures")]
+    pub default_features: Vec<String>,
+}
+impl Default for GuildConfiguration {
+    fn default() -> Self {
+        Self {
+            discovery: DiscoveryConfiguration::default(),
+            auto_join: AutoJoinConfiguration::default(),
+            default_features: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct DiscoveryConfiguration {
+    pub show_all_guilds: bool,
+    pub use_recommendation: bool,
+    pub offset: u32,
+    pub limit: u32,
+}
+impl Default for DiscoveryConfiguration {
+    fn default() -> Self {
+        Self {
+            show_all_guilds: false,
+            use_recommendation: false,
+            offset: 0,
+            limit: 24,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct AutoJoinConfiguration {
+    pub enabled: bool,
+    pub guilds: Vec<String>,
+    #[serde(rename = "canLeave")]
+    pub can_leave: bool,
+}
+impl Default for AutoJoinConfiguration {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            guilds: Vec::new(),
+            can_leave: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct LoginConfiguration {
+    pub require_captcha: bool,
+    pub require_verification: bool,
+}
+impl Default for LoginConfiguration {
+    fn default() -> Self {
+        Self {
+            require_captcha: false,
+            require_verification: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RegisterConfiguration {
+    pub email: RegistrationEmailConfiguration,
+    #[serde(rename = "dateOfBirth")]
+    pub date_of_birth: DateOfBirthConfiguration,
+    pub password: PasswordConfiguration,
+    pub disabled: bool,
+    #[serde(rename = "requireCaptcha")]
+    pub require_captcha: bool,
+    #[serde(rename = "requireInvite")]
+    pub require_invite: bool,
+    #[serde(rename = "guestsRequireInvite")]
+    pub guests_require_invite: bool,
+    #[serde(rename = "allowNewRegistration")]
+    pub allow_new_registration: bool,
+    #[serde(rename = "allowMultipleAccounts")]
+    pub allow_multiple_accounts: bool,
+    #[serde(rename = "blockProxies")]
+    pub block_proxies: bool,
+    #[serde(rename = "incrementingDiscriminators")]
+    pub incrementing_discriminators: bool,
+    #[serde(rename = "defaultRights")]
+    pub default_rights: String,
+}
+impl Default for RegisterConfiguration {
+    fn default() -> Self {
+        Self {
+            email: RegistrationEmailConfiguration::default(),
+            date_of_birth: DateOfBirthConfiguration::default(),
+            password: PasswordConfiguration::default(),
+            disabled: false,
+            require_captcha: true,
+            require_invite: false,
+            guests_require_invite: true,
+            allow_new_registration: true,
+            allow_multiple_accounts: true,
+            block_proxies: true,
+            incrementing_discriminators: false,
+            default_rights: "875069521787904".into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RegistrationEmailConfiguration {
+    pub required: bool,
+    pub allowlist: bool,
+    pub blocklist: bool,
+    pub domains: Vec<String>,
+}
+impl Default for RegistrationEmailConfiguration {
+    fn default() -> Self {
+        Self {
+            required: false,
+            allowlist: false,
+            blocklist: true,
+            domains: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct DateOfBirthConfiguration {
+    pub required: bool,
+    pub minimum: u32,
+}
+impl Default for DateOfBirthConfiguration {
+    fn default() -> Self {
+        Self {
+            required: true,
+            minimum: 13,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct PasswordConfiguration {
+    pub required: bool,
+    #[serde(rename = "minLength")]
+    pub min_length: u32,
+    #[serde(rename = "minNumbers")]
+    pub min_numbers: u32,
+    #[serde(rename = "minUpperCase")]
+    pub min_upper_case: u32,
+    #[serde(rename = "minSymbols")]
+    pub min_symbols: u32,
+}
+impl Default for PasswordConfiguration {
+    fn default() -> Self {
+        Self {
+            required: false,
+            min_length: 8,
+            min_numbers: 2,
+            min_upper_case: 2,
+            min_symbols: 0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct SecurityConfiguration {
+    pub captcha: CaptchaConfiguration,
+    #[serde(rename = "twoFactor")]
+    pub two_factor: TwoFactorConfiguration,
+    #[serde(rename = "autoUpdate")]
+    pub auto_update: AutoUpdate,
+    #[serde(rename = "requestSignature")]
+    pub request_signature: String,
+    #[serde(rename = "jwtSecret")]
+    pub jwt_secret: String,
+    #[serde(rename = "forwardedFor")]
+    pub forwarded_for: Option<String>,
+    #[serde(rename = "trustedProxies")]
+    pub trusted_proxies: Option<serde_json::Value>,
+    #[serde(rename = "ipdataApiKey")]
+    pub ipdata_api_key: Option<String>,
+    #[serde(rename = "mfaBackupCodeCount")]
+    pub mfa_backup_code_count: u32,
+    #[serde(rename = "statsWorldReadable")]
+    pub stats_world_readable: bool,
+    #[serde(rename = "defaultRegistrationTokenExpiration")]
+    pub default_registration_token_expiration: u64,
+    #[serde(rename = "cdnSignUrls")]
+    pub cdn_sign_urls: bool,
+    #[serde(rename = "cdnSignatureKey")]
+    pub cdn_signature_key: String,
+    #[serde(rename = "cdnSignatureDuration")]
+    pub cdn_signature_duration: String,
+    #[serde(rename = "cdnSignatureIncludeIp")]
+    pub cdn_signature_include_ip: bool,
+    #[serde(rename = "cdnSignatureIncludeUserAgent")]
+    pub cdn_signature_include_user_agent: bool,
+}
+impl Default for SecurityConfiguration {
+    fn default() -> Self {
+        Self {
+            captcha: CaptchaConfiguration::default(),
+            two_factor: TwoFactorConfiguration::default(),
+            auto_update: AutoUpdate::Bool(true),
+            request_signature: String::new(),
+            jwt_secret: String::new(),
+            forwarded_for: None,
+            trusted_proxies: None,
+            ipdata_api_key: Some(
+                "eca677b284b3bac29eb72f5e496aa9047f26543605efe99ff2ce35c9".into(),
+            ),
+            mfa_backup_code_count: 10,
+            stats_world_readable: true,
+            default_registration_token_expiration: 1000 * 60 * 60 * 24 * 7,
+            cdn_sign_urls: false,
+            cdn_signature_key: String::new(),
+            cdn_signature_duration: "24h".into(),
+            cdn_signature_include_ip: true,
+            cdn_signature_include_user_agent: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct CaptchaConfiguration {
+    pub enabled: bool,
+    pub service: Option<String>,
+    pub sitekey: Option<String>,
+    pub secret: Option<String>,
+}
+impl Default for CaptchaConfiguration {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            service: None,
+            sitekey: None,
+            secret: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct TwoFactorConfiguration {
+    #[serde(rename = "generateBackupCodes")]
+    pub generate_backup_codes: bool,
+}
+impl Default for TwoFactorConfiguration {
+    fn default() -> Self {
+        Self {
+            generate_backup_codes: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum AutoUpdate {
+    Bool(bool),
+    Number(u64),
+}
+impl Default for AutoUpdate {
+    fn default() -> Self {
+        AutoUpdate::Bool(true)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct LimitsConfiguration {
+    pub user: UserLimits,
+    pub guild: GuildLimits,
+    pub message: MessageLimits,
+    pub channel: ChannelLimits,
+    pub rate: RateLimits,
+    #[serde(rename = "absoluteRate")]
+    pub absolute_rate: GlobalRateLimits,
+}
+impl Default for LimitsConfiguration {
+    fn default() -> Self {
+        Self {
+            user: UserLimits::default(),
+            guild: GuildLimits::default(),
+            message: MessageLimits::default(),
+            channel: ChannelLimits::default(),
+            rate: RateLimits::default(),
+            absolute_rate: GlobalRateLimits::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct UserLimits {
+    pub max_guilds: u32,
+    pub max_username: u32,
+    pub max_friends: u32,
+    pub max_bio: u32,
+}
+impl Default for UserLimits {
+    fn default() -> Self {
+        Self {
+            max_guilds: 1048576,
+            max_username: 32,
+            max_friends: 5000,
+            max_bio: 190,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GuildLimits {
+    pub max_roles: u32,
+    pub max_emojis: u32,
+    pub max_members: u64,
+    pub max_channels: u32,
+    pub max_bulk_ban_users: u32,
+    pub max_channels_in_category: u32,
+}
+impl Default for GuildLimits {
+    fn default() -> Self {
+        Self {
+            max_roles: 1000,
+            max_emojis: 2000,
+            max_members: 25_000_000,
+            max_channels: 65535,
+            max_bulk_ban_users: 200,
+            max_channels_in_category: 65535,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct MessageLimits {
+    pub max_characters: u32,
+    pub max_tts_characters: u32,
+    pub max_reactions: u32,
+    pub max_attachment_size: u64,
+    pub max_bulk_delete: u32,
+    pub max_embed_download_size: u64,
+}
+impl Default for MessageLimits {
+    fn default() -> Self {
+        Self {
+            max_characters: 1_048_576,
+            max_tts_characters: 160,
+            max_reactions: 2048,
+            max_attachment_size: 1024 * 1024 * 1024,
+            max_bulk_delete: 1000,
+            max_embed_download_size: 1024 * 1024 * 5,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ChannelLimits {
+    pub max_pins: u32,
+    pub max_topic: u32,
+    pub max_webhooks: u32,
+}
+impl Default for ChannelLimits {
+    fn default() -> Self {
+        Self {
+            max_pins: 500,
+            max_topic: 1024,
+            max_webhooks: 100,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RateLimits {
+    pub enabled: bool,
+    pub ip: RateLimitOptions,
+    pub global: RateLimitOptions,
+    pub error: RateLimitOptions,
+    pub routes: RouteRateLimit,
+}
+impl Default for RateLimits {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ip: RateLimitOptions {
+                count: 500,
+                window: 5,
+                ..Default::default()
+            },
+            global: RateLimitOptions {
+                count: 250,
+                window: 5,
+                ..Default::default()
+            },
+            error: RateLimitOptions {
+                count: 10,
+                window: 5,
+                ..Default::default()
+            },
+            routes: RouteRateLimit::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RateLimitOptions {
+    pub bot: Option<u32>,
+    pub count: u32,
+    pub window: u32,
+    #[serde(rename = "onyIp")]
+    pub ony_ip: Option<bool>,
+}
+impl Default for RateLimitOptions {
+    fn default() -> Self {
+        Self {
+            bot: None,
+            count: 0,
+            window: 0,
+            ony_ip: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct RouteRateLimit {
+    pub guild: RateLimitOptions,
+    pub webhook: RateLimitOptions,
+    pub channel: RateLimitOptions,
+    pub auth: AuthRateLimit,
+}
+impl Default for RouteRateLimit {
+    fn default() -> Self {
+        Self {
+            guild: RateLimitOptions {
+                count: 5,
+                window: 5,
+                ..Default::default()
+            },
+            webhook: RateLimitOptions {
+                count: 10,
+                window: 5,
+                ..Default::default()
+            },
+            channel: RateLimitOptions {
+                count: 10,
+                window: 5,
+                ..Default::default()
+            },
+            auth: AuthRateLimit::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct AuthRateLimit {
+    pub login: RateLimitOptions,
+    pub register: RateLimitOptions,
+}
+impl Default for AuthRateLimit {
+    fn default() -> Self {
+        Self {
+            login: RateLimitOptions {
+                count: 5,
+                window: 60,
+                ..Default::default()
+            },
+            register: RateLimitOptions {
+                count: 2,
+                window: 60 * 60 * 12,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GlobalRateLimits {
+    pub register: GlobalRateLimit,
+    #[serde(rename = "sendMessage")]
+    pub send_message: GlobalRateLimit,
+}
+impl Default for GlobalRateLimits {
+    fn default() -> Self {
+        Self {
+            register: GlobalRateLimit {
+                limit: 25,
+                window: 60 * 60 * 1000,
+                enabled: true,
+            },
+            send_message: GlobalRateLimit {
+                limit: 200,
+                window: 60 * 1000,
+                enabled: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GlobalRateLimit {
+    pub limit: u32,
+    pub window: u32,
+    pub enabled: bool,
+}
+impl Default for GlobalRateLimit {
+    fn default() -> Self {
+        Self {
+            limit: 100,
+            window: 60 * 60 * 1000,
+            enabled: true,
+        }
+    }
+}

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -1,3 +1,0 @@
-pub fn placeholder() {
-    println!("util library placeholder");
-}


### PR DESCRIPTION
## Summary
- add `util/config` crate for shared server configuration
- use serde and tokio to load JSON config into global `Arc`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_b_68b55150145c83299532efeb1024595f