### PR TITLE
feat: add tokio-based gateway websocket server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -504,8 +505,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -1220,6 +1223,15 @@ dependencies = [
 [[package]]
 name = "gateway"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "config",
+ "events",
+ "futures-util",
+ "tokio",
+ "util-db",
+]
 
 [[package]]
 name = "generic-array"
@@ -3479,6 +3491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,6 +3623,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -4,3 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1"
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+futures-util = "0.3"
+config = { path = "../util/config" }
+util-db = { path = "../util/db" }
+events = { path = "../events" }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1,3 +1,127 @@
-fn main() {
-    println!("gateway service placeholder");
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+
+use anyhow::Result;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        ConnectInfo, State,
+    },
+    response::Response,
+    routing::get,
+    serve, Router,
+};
+use config::Config;
+use events::init_event;
+use tokio::{
+    net::TcpListener,
+    signal,
+    sync::{oneshot, Mutex},
+};
+use util_db::{close_database, init_database, DbPool};
+
+#[derive(Clone)]
+struct GatewayState {
+    db: DbPool,
+    config: Arc<Config>,
+    connections: Arc<Mutex<HashSet<SocketAddr>>>,
+}
+
+pub struct GatewayServer {
+    port: u16,
+    state: Option<GatewayState>,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl GatewayServer {
+    pub fn new(port: u16) -> Self {
+        Self {
+            port,
+            state: None,
+            shutdown: None,
+            handle: None,
+        }
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        let config = Config::init().await;
+        let database_url =
+            std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite::memory:".into());
+        let db = init_database(&database_url).await?;
+        init_event().await?;
+
+        let state = GatewayState {
+            db,
+            config,
+            connections: Arc::new(Mutex::new(HashSet::new())),
+        };
+        self.state = Some(state.clone());
+
+        let app = Router::new()
+            .route("/ws", get(ws_handler))
+            .with_state(state);
+
+        let addr = SocketAddr::from(([0, 0, 0, 0], self.port));
+        let listener = TcpListener::bind(addr).await?;
+        let (tx, rx) = oneshot::channel();
+        let server = serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async {
+            let _ = rx.await;
+        });
+
+        self.handle = Some(tokio::spawn(async move {
+            let _ = server.await;
+        }));
+        self.shutdown = Some(tx);
+        println!("[Gateway] listening on {}", addr);
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+        if let Some(state) = self.state.take() {
+            close_database(state.db).await;
+        }
+    }
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<GatewayState>,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, addr, state))
+}
+
+async fn handle_socket(mut socket: WebSocket, addr: SocketAddr, state: GatewayState) {
+    state.connections.lock().await.insert(addr);
+    let total = state.connections.lock().await.len();
+    println!("[Gateway] New connection from {}, total {}", addr, total);
+
+    while let Some(Ok(msg)) = socket.recv().await {
+        if let Message::Close(_) = msg {
+            break;
+        }
+    }
+
+    state.connections.lock().await.remove(&addr);
+    let total = state.connections.lock().await.len();
+    println!("[Gateway] Connection closed from {}, total {}", addr, total);
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut server = GatewayServer::new(3001);
+    server.start().await?;
+    let _ = signal::ctrl_c().await;
+    server.stop().await;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add Gateway server crate using Axum WebSocket handling
- initialize config, database and events before listening
- provide start/stop methods for managing the gateway lifecycle

## Testing
- `cargo test -p gateway`

------
https://chatgpt.com/codex/tasks/task_b_68b570ffb6a483299b2117336277d373