### PR TITLE
feat(cdn): serve assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,18 @@ dependencies = [
 [[package]]
 name = "cdn"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "config",
+ "mime_guess",
+ "sqlx",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing-subscriber",
+ "util-db",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1828,6 +1840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1901,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2471,7 +2502,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2961,6 +2992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +3597,23 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.9.3",
+ "bytes",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
@@ -3610,12 +3676,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3656,6 +3738,12 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/cdn/Cargo.toml
+++ b/crates/cdn/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1"
+axum = { version = "0.7", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "fs"] }
+tower = "0.4"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+tracing-subscriber = "0.3"
+mime_guess = "2"
+config = { path = "../util/config" }
+util-db = { path = "../util/db" }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "macros", "mysql", "postgres", "sqlite", "any"] }

--- a/crates/cdn/src/main.rs
+++ b/crates/cdn/src/main.rs
@@ -1,3 +1,213 @@
-fn main() {
-    println!("cdn service placeholder");
+//! CDN service for serving static assets.
+
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Result;
+use axum::{
+    extract::{MatchedPath, Path as AxumPath, State},
+    http::{header, StatusCode},
+    response::Response,
+    routing::get,
+    Router,
+};
+use config::Config;
+use tokio::{fs, net::TcpListener, signal};
+use tower::ServiceBuilder;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+
+use util_db::{init_database, DbPool};
+
+/// Shared application state.
+#[derive(Clone)]
+struct AppState {
+    storage_root: Arc<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // Load configuration and database.
+    let _config = Config::init().await;
+    let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite::memory:".into());
+    let db = init_database(&database_url).await?;
+
+    // Run clean-up for any stale attachment signatures.
+    cleanup_attachment_signatures(&db).await.ok();
+
+    // Determine storage location for files.
+    let storage_root = std::env::var("STORAGE_LOCATION").unwrap_or_else(|_| "files".to_string());
+    let storage_root = Arc::new(PathBuf::from(storage_root));
+
+    let state = AppState { storage_root };
+
+    // Build application with routes and middleware.
+    let mut app = Router::new()
+        .nest("/avatars", avatars_router())
+        .nest("/role-icons", role_icons_router())
+        .nest("/emojis", avatars_router())
+        .nest(
+            "/guilds/:guild_id/users/:user_id/avatars",
+            guild_profile_router(),
+        )
+        .with_state(state)
+        .layer(
+            ServiceBuilder::new()
+                .layer(CorsLayer::new().allow_methods(Any).allow_origin(Any))
+                .layer(axum::extract::DefaultBodyLimit::max(10 * 1024 * 1024)),
+        );
+
+    // Enable request logging if requested.
+    if std::env::var("LOG_REQUESTS").is_ok() {
+        app = app.layer(TraceLayer::new_for_http());
+    }
+
+    let addr: SocketAddr = "0.0.0.0:3001".parse().unwrap();
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let _ = signal::ctrl_c().await;
+}
+
+/// Router for user avatars and other generic asset folders that follow the same
+/// `:id/:hash` pattern.
+fn avatars_router() -> Router<AppState> {
+    Router::new()
+        .route("/:id", get(get_simple_file))
+        .route("/:id/:hash", get(get_nested_file))
+}
+
+/// Router for guild profile assets under
+/// `/guilds/:guild_id/users/:user_id/avatars`.
+fn guild_profile_router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_guild_profile_root))
+        .route("/:hash", get(get_guild_profile_file))
+}
+
+/// Router for role icons which follow the `:role_id/:hash` pattern.
+fn role_icons_router() -> Router<AppState> {
+    Router::new().route("/:role_id/:hash", get(get_nested_file))
+}
+
+/// Serve a file directly under `<storage>/<route>/<id>`.
+async fn get_simple_file(
+    AxumPath(id): AxumPath<String>,
+    State(state): State<AppState>,
+    matched: MatchedPath,
+) -> Result<Response, StatusCode> {
+    let route = route_base(matched.as_str())?;
+    let path = state.storage_root.join(route).join(id);
+    serve_path(&path).await
+}
+
+/// Serve a file under `<storage>/<route>/<id>/<hash>`.
+async fn get_nested_file(
+    AxumPath((id, hash)): AxumPath<(String, String)>,
+    State(state): State<AppState>,
+    matched: MatchedPath,
+) -> Result<Response, StatusCode> {
+    let route = route_base(matched.as_str())?;
+    let path = state.storage_root.join(route).join(id).join(hash);
+    serve_path(&path).await
+}
+
+/// Serve the avatar stored for a guild member without specifying a hash.
+async fn get_guild_profile_root(
+    AxumPath((guild_id, user_id)): AxumPath<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<Response, StatusCode> {
+    let path = state
+        .storage_root
+        .join("guilds")
+        .join(guild_id)
+        .join("users")
+        .join(user_id)
+        .join("avatars");
+    serve_path(&path).await
+}
+
+/// Serve a specific guild profile avatar hash.
+async fn get_guild_profile_file(
+    AxumPath((guild_id, user_id, hash)): AxumPath<(String, String, String)>,
+    State(state): State<AppState>,
+) -> Result<Response, StatusCode> {
+    let path = state
+        .storage_root
+        .join("guilds")
+        .join(guild_id)
+        .join("users")
+        .join(user_id)
+        .join("avatars")
+        .join(hash);
+    serve_path(&path).await
+}
+
+/// Utility to derive the first component of the matched route path.
+fn route_base(path: &str) -> Result<&str, StatusCode> {
+    path.trim_start_matches('/')
+        .split('/')
+        .next()
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+/// Read a file from disk and return it as a response with appropriate headers.
+async fn serve_path(path: &Path) -> Result<Response, StatusCode> {
+    match fs::read(path).await {
+        Ok(contents) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            let res = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CACHE_CONTROL, "public, max-age=31536000")
+                .header(header::CONTENT_TYPE, mime.as_ref())
+                .body(axum::body::Body::from(contents))
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            Ok(res)
+        }
+        Err(_) => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+/// Remove any stale signature parameters from attachment URLs in the database.
+async fn cleanup_attachment_signatures(db: &DbPool) -> Result<(), sqlx::Error> {
+    use sqlx::Row;
+
+    let rows = sqlx::query(
+        "SELECT id, url, proxy_url FROM attachments WHERE url LIKE '%?ex=%' OR proxy_url LIKE '%?ex=%'",
+    )
+    .fetch_all(db)
+    .await?;
+
+    for row in rows {
+        let id: String = row.try_get("id")?;
+        let url: Option<String> = row.try_get("url")?;
+        let proxy_url: Option<String> = row.try_get("proxy_url")?;
+
+        let new_url = url.map(|u| u.split("?ex=").next().unwrap().to_string());
+        let new_proxy = proxy_url.map(|u| u.split("?ex=").next().unwrap().to_string());
+
+        sqlx::query("UPDATE attachments SET url = ?, proxy_url = ? WHERE id = ?")
+            .bind(new_url)
+            .bind(new_proxy)
+            .bind(id)
+            .execute(db)
+            .await?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add axum-based CDN server serving avatars, role icons, emojis and guild profile assets
- include CORS, body-size limits and optional request logging
- cleanup attachment URL signatures in the database on startup

## Testing
- `cargo test -p cdn`


------
https://chatgpt.com/codex/tasks/task_b_68b5797e8fc4832997098ffb3886c74c