### PR TITLE
Add cross-platform CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --workspace --target ${{ matrix.target }}
+      - name: Test
+        run: cargo test
+      - name: Build release
+        run: cargo build --workspace --target ${{ matrix.target }} --release
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test on Linux and Windows targets

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b6ac2922fc8329ae3c32c91834e226